### PR TITLE
기술 글 리스트 추가

### DIFF
--- a/multi_final/back/final/src/main/java/com/finalp/tech/TechController.java
+++ b/multi_final/back/final/src/main/java/com/finalp/tech/TechController.java
@@ -38,36 +38,66 @@ public class TechController {
 		
 		@GetMapping("/itTech/react")
 		public Map<String, Object> getReactArticle() {
-			Map<String, Object> articlesMap = new HashMap<String, Object>();
-			ArrayList<Object> articlesArray = new ArrayList<Object>();
-			Map<String, String> titleMap = new HashMap<String, String>();
+			Map<String, Object> reactMap = new HashMap<String, Object>();
+			ArrayList<Object> reactArray = new ArrayList<Object>();
+			
 //			Document doc = Jsoup.connect("https://ko.reactjs.org/blog/all.html").get();
 			try {
 				Document reactDoc = Jsoup.connect("https://ko.reactjs.org/blog/all.html").get();
-				Element titleE;
+				Element reactEl;
 				
 				for(int i = 0; i <= 2; i++) {
-					titleE = reactDoc.select("body h2").get(i);
-					String title = titleE.text();
-					String titleLink = titleE.html().replaceAll("<a class=\"css-m6cbzp\" href=\"", "");
+					reactEl = reactDoc.select("body h2").get(i);
+					String title = reactEl.text();
+					String titleLink = reactEl.html().replaceAll("<a class=\"css-m6cbzp\" href=\"", "");
 					titleLink = titleLink.substring(0, titleLink.indexOf("\""));
 					System.out.println(title);
 					//리액트로 보낼 데이터
+					Map<String, String> titleMap = new HashMap<String, String>();
 					titleMap.put("title", title);
 					titleMap.put("titleLink", titleLink);
-					articlesArray.add(titleMap);
-					articlesMap.put("articles", articlesArray);
+					reactArray.add(i, titleMap);
+					System.out.println(reactArray);
+					reactMap.put("articles", reactArray);
 				}
 			
-				System.out.println(articlesMap);
+				System.out.println(reactMap);
 			} catch (IOException e) {
 				e.printStackTrace();
 			}
+			return reactMap;
+		}
+		
+		@GetMapping("/itTech/spring")
+		public Map<String, Object> getSpringArticle() {
+			Map<String, Object> springMap = new HashMap<String, Object>();
+			ArrayList<Object> springArray = new ArrayList<Object>();
+			try {
+				Document springDoc = Jsoup.connect("https://spring.io/blog").get();
+				Element springEl;
+				
+				for(int i = 0; i <= 2; i++) {
+					springEl = springDoc.select("body h2").get(i);
+					String title = springEl.text();
+					String titleLink = springEl.html().replaceAll("<a href=\"", "");
+					titleLink = titleLink.substring(0, titleLink.indexOf("\""));
+					title = title.replace(",", " ");
+					System.out.println(title);
+					//리액트로 보낼 데이터
+					Map<String, String> titleMap = new HashMap<String, String>();
+					titleMap.put("title", title);
+					titleMap.put("titleLink", titleLink);
+					springArray.add(i, titleMap);
+					System.out.println(springArray);
+					springMap.put("articles", springArray);
+				}
 			
-			
-			
-			
-			return articlesMap;
+				System.out.println(springMap);
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
+		
+			return springMap;
 		}
 	}
 

--- a/multi_final/back/final/src/main/java/com/finalp/tech/TechController.java
+++ b/multi_final/back/final/src/main/java/com/finalp/tech/TechController.java
@@ -1,7 +1,14 @@
 package com.finalp.tech;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -27,6 +34,40 @@ public class TechController {
 		@GetMapping("/itTech/{no}")
 		public List<techDTO> getnoticeList(@PathVariable("no") int no) {
 			return mapper.gettechList(no);
+		}
+		
+		@GetMapping("/itTech/react")
+		public Map<String, Object> getReactArticle() {
+			Map<String, Object> articlesMap = new HashMap<String, Object>();
+			ArrayList<Object> articlesArray = new ArrayList<Object>();
+			Map<String, String> titleMap = new HashMap<String, String>();
+//			Document doc = Jsoup.connect("https://ko.reactjs.org/blog/all.html").get();
+			try {
+				Document reactDoc = Jsoup.connect("https://ko.reactjs.org/blog/all.html").get();
+				Element titleE;
+				
+				for(int i = 0; i <= 2; i++) {
+					titleE = reactDoc.select("body h2").get(i);
+					String title = titleE.text();
+					String titleLink = titleE.html().replaceAll("<a class=\"css-m6cbzp\" href=\"", "");
+					titleLink = titleLink.substring(0, titleLink.indexOf("\""));
+					System.out.println(title);
+					//리액트로 보낼 데이터
+					titleMap.put("title", title);
+					titleMap.put("titleLink", titleLink);
+					articlesArray.add(titleMap);
+					articlesMap.put("articles", articlesArray);
+				}
+			
+				System.out.println(articlesMap);
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
+			
+			
+			
+			
+			return articlesMap;
 		}
 	}
 

--- a/multi_final/back/final/src/main/java/com/finalp/tech/TechController.java
+++ b/multi_final/back/final/src/main/java/com/finalp/tech/TechController.java
@@ -99,6 +99,40 @@ public class TechController {
 		
 			return springMap;
 		}
+		
+		@GetMapping("/itTech/vue")
+		public Map<String, Object> getVueArciles() {
+			Map<String, Object> vueMap = new HashMap<String, Object>();
+			ArrayList<Object> vueArray = new ArrayList<Object>();
+			try {
+				Document vueDoc = Jsoup.connect("https://news.vuejs.org/archive").get();
+				Element vueEl;
+				
+				for(int i = 0; i <= 2; i++) {
+					vueEl = vueDoc.getElementsByClass("issue-title").get(i);
+					String title = vueEl.text();
+					vueEl = vueDoc.getElementsByAttributeValueStarting("href", "/issues/").get(i);
+					String titleLink = vueEl.attr("href");
+//					titleLink = titleLink.substring(0, titleLink.indexOf("\""));
+					title = title.replace(",", " ");
+					System.out.println(title);
+					System.out.println(titleLink);
+					//리액트로 보낼 데이터
+					Map<String, String> titleMap = new HashMap<String, String>();
+					titleMap.put("title", title);
+					titleMap.put("titleLink", titleLink);
+					vueArray.add(i, titleMap);
+					System.out.println(vueArray);
+					vueMap.put("articles", vueArray);
+				}
+			
+				System.out.println(vueMap);
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
+			
+			return vueMap;
+		}
 	}
 
 

--- a/multi_final/back/final/src/main/resources/application.properties
+++ b/multi_final/back/final/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 server.port=8085
 
-spring.datasource.url=jdbc:mysql://localhost:3306/mydb?useSSL=false&characterEncoding=UTF-8&serverTimezone=UTC
+spring.datasource.url=jdbc:mysql://localhost:3306/mydb?useSSL=false&characterEncoding=UTF-8&serverTimezone=UTC&allowPublicKeyRetrieval=true&useSSL=false
 spring.datasource.username=root
 spring.datasource.password=1234
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver

--- a/multi_final/front/workspace_react/package-lock.json
+++ b/multi_final/front/workspace_react/package-lock.json
@@ -27,7 +27,7 @@
         "react-dom": "^17.0.2",
         "react-hook-form": "^7.27.0",
         "react-router-dom": "^6.2.1",
-        "react-scripts": "5.0.0",
+        "react-scripts": "^5.0.0",
         "redux": "^4.1.2",
         "sass": "^1.49.7",
         "string-replace-all": "^1.0.3",

--- a/multi_final/front/workspace_react/package.json
+++ b/multi_final/front/workspace_react/package.json
@@ -22,7 +22,7 @@
     "react-dom": "^17.0.2",
     "react-hook-form": "^7.27.0",
     "react-router-dom": "^6.2.1",
-    "react-scripts": "5.0.0",
+    "react-scripts": "^5.0.0",
     "redux": "^4.1.2",
     "sass": "^1.49.7",
     "string-replace-all": "^1.0.3",

--- a/multi_final/front/workspace_react/src/components/main/MainCarousel.js
+++ b/multi_final/front/workspace_react/src/components/main/MainCarousel.js
@@ -12,34 +12,6 @@ const titleUrl = (title) => {
 };
 
 const MainCarousel = () => {
-    const [articles1, setArticles1] = useState(null);
-    const[loading, setLoading] = useState(false);
-    const [error, setError] = useState(null);
-    useEffect(() => {
-        const fetchData = async() => {
-            setLoading(true);
-            try {
-                const response = await axios.get('http://localhost:8085/article1');
-                console.log(response);
-                setArticles1(response.data);
-                console.log(articles1);
-            } catch (error) {
-                setError(error);
-                console.log(error);
-            }
-            setLoading(false);
-        };
-        fetchData();
-    },[]);
-    if (loading) {
-        return null;
-    }
-    if (error) {
-      return <div>오류가 발생했습니다. 관리자에게 문의해주세요.</div>
-    }
-    if(!articles1) {
-        return <div>오류가 발생했습니다. 관리자에게 문의해주세요.</div>;
-    }
     return (
       <div
         style={{
@@ -55,16 +27,10 @@ const MainCarousel = () => {
         className="carousel"
       >
         <Carousel fade>
-          {articles1.articles.map((a, index) => (
+          
             <Carousel.Item>
-              <Link to={'/itTrend/'+ titleUrl(a.title)}>
-                <img className="d-flex" src={a.urlToImage} alt="First slide" width={300} height={200}/>
-                {a.title}
-                <br />
-                {/* {a.description} */}
-              </Link>
+              
             </Carousel.Item>
-          ))}
         </Carousel>
       </div>
     );

--- a/multi_final/front/workspace_react/src/page/itTechnology/ItTechnologyReact.js
+++ b/multi_final/front/workspace_react/src/page/itTechnology/ItTechnologyReact.js
@@ -1,0 +1,46 @@
+import React, { useState , useEffect} from 'react';
+import 'bootstrap/dist/css/bootstrap.min.css';
+import './itTechnologyMain.scss'
+import { Link } from 'react-router-dom';
+import axios from 'axios';
+
+
+const ItTechnologyReact = () => {
+    const [techReact, setTechReact] = useState(null);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState(null);
+    useEffect(() => {
+        const fetchData = async() => {
+            setLoading(true);
+            try {
+                const response = await axios.get("http://localhost:8085/itTech/react");
+                console.log(response);
+                setTechReact(response.data);
+            } catch (error) {
+                setError(error);
+            }
+            setLoading(false);
+        };
+        fetchData();
+    }, []);
+    if(loading) return <div>로딩중</div>
+    if(error) return <div>오류가 발생했습니다. 관리자에게 문의해주세요.</div>
+    if(!techReact) return null;
+    return (
+        <div>
+            {/* <Link to={'React/'+techReact.title} className="itTechLink"> */}
+                <span className="itTechSpan">
+                    <img width="200px" height="200px" src="https://t1.daumcdn.net/cfile/tistory/24457C4F58663DD011" alt="img" />
+                    {techReact.articles.map((a, index) => (
+                        <div key={index}>
+                            <p className="boardTitle" onClick={() => window.open(`https://ko.reactjs.org${a.titleLink}`, "_blank")}>{a.title}</p>
+                        </div>
+                    ))}
+                </span>
+                {/* <button onClick={() => window.open(`https://ko.reactjs.org${techReact.titleLink}`, "_blank")}>원문보기</button> */}
+            {/* </Link> */}
+        </div>
+    );
+};
+
+export default ItTechnologyReact;

--- a/multi_final/front/workspace_react/src/page/itTechnology/ItTechnologySpring.js
+++ b/multi_final/front/workspace_react/src/page/itTechnology/ItTechnologySpring.js
@@ -1,0 +1,41 @@
+import React, { useState , useEffect} from 'react';
+import 'bootstrap/dist/css/bootstrap.min.css';
+import './itTechnologyMain.scss'
+import { Link } from 'react-router-dom';
+import axios from 'axios';
+
+const ItTechnologySpring = () => {
+    const [techSpring, setTechSpring] = useState(null);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState(null);
+    useEffect(() => {
+        const fetchData = async() => {
+            setLoading(true);
+            try {
+                const resposne = await axios.get("http://localhost:8085/itTech/spring");
+                setTechSpring(resposne.data);
+            } catch (error) {
+                setError(error);
+            }
+            setLoading(false);
+        }
+        fetchData();
+    }, []);
+    if(loading) return <div>로딩중</div>
+    if(error) return <div>오류가 발생했습니다. 관리자에게 문의해주세요.</div>
+    if(!techSpring) return null;
+    return (
+        <div>
+            <span className="itTechSpan">
+                <img width="200px" height="200px" src="https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FpFPRd%2FbtqCYFM6mA1%2FhC9HgrhsJwI38qEdCRqUG0%2Fimg.png" alt="img" />
+                {techSpring.articles.map((a, index) => (
+                    <div key={index}>
+                        <p className="boardTitle" onClick={() => window.open(`https://spring.io${a.titleLink}`, "_blank")}>{a.title}</p>
+                    </div>
+                ))}
+            </span>
+        </div>
+    );
+};
+
+export default ItTechnologySpring;

--- a/multi_final/front/workspace_react/src/page/itTechnology/ItTechnologyVue.js
+++ b/multi_final/front/workspace_react/src/page/itTechnology/ItTechnologyVue.js
@@ -1,0 +1,41 @@
+import React, { useState , useEffect} from 'react';
+import 'bootstrap/dist/css/bootstrap.min.css';
+import './itTechnologyMain.scss'
+import { Link } from 'react-router-dom';
+import axios from 'axios';
+
+const ItTechnologyVue = () => {
+    const [techVue, setTechVue] = useState(null);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState(null);
+    useEffect(() => {
+        const fetchData = async() => {
+            setLoading(true);
+            try {
+                const resposne = await axios.get("http://localhost:8085/itTech/vue");
+                setTechVue(resposne.data);
+            } catch (error) {
+                setError(error);
+            }
+            setLoading(false);
+        }
+        fetchData();
+    }, []);
+    if(loading) return <div>로딩중</div>
+    if(error) return <div>오류가 발생했습니다. 관리자에게 문의해주세요.</div>
+    if(!techVue) return null;
+    return (
+        <div>
+            <span className="itTechSpan">
+                <img width="200px" height="200px" src="https://v3.ko.vuejs.org/logo.png" alt="img" />
+                {techVue.articles.map((a, index) => (
+                    <div key={index}>
+                        <p className="boardTitle" onClick={() => window.open(`https://news.vuejs.org/${a.titleLink}`, "_blank")}>{a.title}</p>
+                    </div>
+                ))}
+            </span>
+        </div>
+    );
+};
+
+export default ItTechnologyVue;

--- a/multi_final/front/workspace_react/src/page/itTechnology/itTechnologyMain.js
+++ b/multi_final/front/workspace_react/src/page/itTechnology/itTechnologyMain.js
@@ -3,6 +3,7 @@ import 'bootstrap/dist/css/bootstrap.min.css';
 import './itTechnologyMain.scss'
 import { Link } from 'react-router-dom';
 import axios from 'axios';
+import ItTechnologyReact from './ItTechnologyReact';
 
 
 const ItTechnologyMain=()=>{
@@ -40,7 +41,7 @@ if (!techs) return null;
             <p className='itTechPageTitle'>IT 기술</p>
             <div>
                 <ul className="skill_list">
-                    {techs.map((tech)=>(
+                    {/* {techs.map((tech)=>(
                         <li key={tech.no}>
                             <Link to={"/itTech/" + tech.no} className="itTechLink">
                                 <span className='itTechSpan'>
@@ -52,7 +53,8 @@ if (!techs) return null;
                                 </span>
                             </Link>
                         </li>
-                    ))}
+                    ))} */}
+                    <ItTechnologyReact/>
                 </ul>
                 </div>
             </div>

--- a/multi_final/front/workspace_react/src/page/itTechnology/itTechnologyMain.js
+++ b/multi_final/front/workspace_react/src/page/itTechnology/itTechnologyMain.js
@@ -5,6 +5,7 @@ import { Link } from 'react-router-dom';
 import axios from 'axios';
 import ItTechnologyReact from './ItTechnologyReact';
 import ItTechnologySpring from './ItTechnologySpring';
+import ItTechnologyVue from './ItTechnologyVue';
 
 
 const ItTechnologyMain=()=>{
@@ -57,6 +58,7 @@ if (!techs) return null;
                     ))} */}
                     <ItTechnologyReact/>
                     <ItTechnologySpring/>
+                    <ItTechnologyVue/>
                 </ul>
                 </div>
             </div>

--- a/multi_final/front/workspace_react/src/page/itTechnology/itTechnologyMain.js
+++ b/multi_final/front/workspace_react/src/page/itTechnology/itTechnologyMain.js
@@ -4,6 +4,7 @@ import './itTechnologyMain.scss'
 import { Link } from 'react-router-dom';
 import axios from 'axios';
 import ItTechnologyReact from './ItTechnologyReact';
+import ItTechnologySpring from './ItTechnologySpring';
 
 
 const ItTechnologyMain=()=>{
@@ -55,6 +56,7 @@ if (!techs) return null;
                         </li>
                     ))} */}
                     <ItTechnologyReact/>
+                    <ItTechnologySpring/>
                 </ul>
                 </div>
             </div>

--- a/multi_final/front/workspace_react/yarn.lock
+++ b/multi_final/front/workspace_react/yarn.lock
@@ -8346,7 +8346,7 @@
   dependencies:
     "history" "^5.2.0"
 
-"react-scripts@5.0.0":
+"react-scripts@^5.0.0":
   "integrity" "sha512-3i0L2CyIlROz7mxETEdfif6Sfhh9Lfpzi10CtcGs1emDQStmZfWjJbAIMtRD0opVUjQuFWqHZyRZ9PPzKCFxWg=="
   "resolved" "https://registry.npmjs.org/react-scripts/-/react-scripts-5.0.0.tgz"
   "version" "5.0.0"


### PR DESCRIPTION
- 공식사이트에 올라오는 공식블로그 글목록을 긁어와서 보여줍니다 공식사이트에 글 업데이트되면 여기도 반영될거에요
- 글 제목이 지금은 가로로 정렬됐는데 한 항목당 세 개씩 리스트처럼 보여지게 수정하면 될것같습니다